### PR TITLE
IPC GUI fix bots collapse button

### DIFF
--- a/ArchiSteamFarm/www/pages/bots.html
+++ b/ArchiSteamFarm/www/pages/bots.html
@@ -497,8 +497,8 @@
                                 + deleteBotHTML
                                 + expandBoxHTML
                                 + '</div>'
-                                + boxBodyHTML
                                 + '</div>'
+                                + boxBodyHTML
                                 + '</div>'
                                 + '</div>');
 


### PR DESCRIPTION
If I am not wrong, the boxBodyHTML content wasn't properly placed, causing the collapse button to not work properly (collapse worked but pressing the - wasn't doing anything).